### PR TITLE
Refactor waterfall UI into modular components and hooks

### DIFF
--- a/frontend/src/components/waterfall/useWaterfallStream.js
+++ b/frontend/src/components/waterfall/useWaterfallStream.js
@@ -1,0 +1,204 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useSocket } from '../common/socket.jsx';
+import {
+    setCenterFrequency,
+    setSampleRate,
+    setGain,
+    setFFTSize,
+    setFFTWindow,
+    setBiasT,
+    setTunerAgc,
+    setRtlAgc,
+    setFFTAveraging,
+    setIsStreaming,
+    setErrorMessage,
+    setErrorDialogOpen,
+    setStartStreamingLoading,
+    setFFTdataOverflow
+} from './waterfall-slice.jsx';
+import { enqueueSnackbar } from 'notistack';
+
+const useWaterfallStream = ({ workerRef, targetFPSRef }) => {
+    const dispatch = useDispatch();
+    const { socket } = useSocket();
+    const {
+        selectedSDRId,
+        centerFrequency,
+        sampleRate,
+        gain,
+        fftSize,
+        biasT,
+        tunerAgc,
+        rtlAgc,
+        fftWindow,
+        selectedAntenna,
+        selectedOffsetValue,
+        soapyAgc,
+        fftAveraging,
+        isStreaming,
+        gettingSDRParameters,
+        autoDBRange,
+        vfoActive,
+    } = useSelector((state) => state.waterfall);
+
+    const animationFrameRef = useRef(null);
+    const bandscopeAnimationFrameRef = useRef(null);
+    const timestampWindowRef = useRef([]);
+    const overflowRef = useRef(false);
+    const allowedIntervalRef = useRef(0);
+    const lastAllowedUpdateRef = useRef(0);
+    const windowSizeMs = 1000;
+    const fftDataOverflowLimit = 60;
+
+    const cancelAnimations = useCallback(() => {
+        if (workerRef.current) {
+            workerRef.current.postMessage({ cmd: 'stop' });
+        }
+        if (animationFrameRef.current) {
+            cancelAnimationFrame(animationFrameRef.current);
+            animationFrameRef.current = null;
+        }
+        if (bandscopeAnimationFrameRef.current) {
+            cancelAnimationFrame(bandscopeAnimationFrameRef.current);
+            bandscopeAnimationFrameRef.current = null;
+        }
+    }, [workerRef]);
+
+    useEffect(() => {
+        socket.on('disconnect', () => {
+            cancelAnimations();
+            dispatch(setIsStreaming(false));
+        });
+
+        socket.on('sdr-config-error', (error) => {
+            dispatch(setErrorMessage(error.message));
+            dispatch(setErrorDialogOpen(true));
+            dispatch(setStartStreamingLoading(false));
+            enqueueSnackbar(`Failed to configure SDR: ${error.message}`, { variant: 'error' });
+        });
+
+        socket.on('sdr-error', (error) => {
+            cancelAnimations();
+            dispatch(setErrorMessage(error.message));
+            dispatch(setErrorDialogOpen(true));
+            dispatch(setStartStreamingLoading(false));
+        });
+
+        socket.on('sdr-config', (data) => {
+            dispatch(setCenterFrequency(data['center_freq']));
+            dispatch(setSampleRate(data['sample_rate']));
+            dispatch(setGain(data['gain']));
+            dispatch(setFFTSize(data['fft_size']));
+            dispatch(setFFTWindow(data['fft_window']));
+            dispatch(setBiasT(data['bias_t']));
+            dispatch(setTunerAgc(data['tuner_agc']));
+            dispatch(setRtlAgc(data['rtl_agc']));
+            dispatch(setFFTAveraging(data['fft_averaging']));
+        });
+
+        socket.on('sdr-status', (data) => {
+            if (data['streaming'] === true) {
+                dispatch(setIsStreaming(true));
+                dispatch(setStartStreamingLoading(false));
+            } else if (data['streaming'] === false) {
+                cancelAnimations();
+                dispatch(setIsStreaming(false));
+                dispatch(setStartStreamingLoading(false));
+            }
+        });
+
+        socket.on('sdr-fft-data', (binaryData) => {
+            const now = performance.now();
+            timestampWindowRef.current.push(now);
+            const cutoffTime = now - windowSizeMs;
+            while (timestampWindowRef.current.length > 0 && timestampWindowRef.current[0] < cutoffTime) {
+                timestampWindowRef.current.shift();
+            }
+            const currentRate = timestampWindowRef.current.length;
+            const shouldOverflow = currentRate > fftDataOverflowLimit;
+            if (shouldOverflow !== overflowRef.current) {
+                overflowRef.current = shouldOverflow;
+                dispatch(setFFTdataOverflow(shouldOverflow));
+                allowedIntervalRef.current = 1000 / fftDataOverflowLimit;
+            }
+            if (overflowRef.current) {
+                const timeSinceLastAllowed = now - lastAllowedUpdateRef.current;
+                if (timeSinceLastAllowed < allowedIntervalRef.current) {
+                    timestampWindowRef.current.pop();
+                    return;
+                }
+                lastAllowedUpdateRef.current = now;
+            }
+            const floatArray = new Float32Array(binaryData);
+            if (workerRef.current) {
+                workerRef.current.postMessage({
+                    cmd: 'updateFFTData',
+                    fft: floatArray,
+                    immediate: true,
+                });
+            }
+        });
+
+        return () => {
+            cancelAnimations();
+            socket.off('sdr-config-error');
+            socket.off('sdr-error');
+            socket.off('sdr-fft-data');
+            socket.off('sdr-status');
+            socket.off('sdr-config');
+        };
+    }, [socket, cancelAnimations, dispatch, workerRef]);
+
+    const startStreaming = useCallback(() => {
+        if (!isStreaming) {
+            dispatch(setStartStreamingLoading(true));
+            dispatch(setErrorMessage(''));
+            socket.emit('sdr_data', 'configure-sdr', {
+                selectedSDRId,
+                centerFrequency,
+                sampleRate,
+                gain,
+                fftSize,
+                biasT,
+                tunerAgc,
+                rtlAgc,
+                fftWindow,
+                antenna: selectedAntenna,
+                offsetFrequency: selectedOffsetValue,
+                soapyAgc,
+                fftAveraging,
+            }, (response) => {
+                if (response['success']) {
+                    socket.emit('sdr_data', 'start-streaming', { selectedSDRId });
+                    if (workerRef.current) {
+                        workerRef.current.postMessage({
+                            cmd: 'start',
+                            data: { fps: targetFPSRef.current }
+                        });
+                    }
+                }
+            });
+        }
+    }, [isStreaming, dispatch, socket, selectedSDRId, centerFrequency, sampleRate, gain, fftSize, biasT, tunerAgc, rtlAgc, fftWindow, selectedAntenna, selectedOffsetValue, soapyAgc, fftAveraging, workerRef, targetFPSRef]);
+
+    const stopStreaming = useCallback(() => {
+        if (isStreaming) {
+            socket.emit('sdr_data', 'stop-streaming', { selectedSDRId });
+            dispatch(setIsStreaming(false));
+            cancelAnimations();
+        }
+    }, [isStreaming, socket, selectedSDRId, dispatch, cancelAnimations]);
+
+    const playButtonEnabledOrNot = useCallback(() => {
+        const isStreamingActive = isStreaming;
+        const noSDRSelected = selectedSDRId === 'none';
+        const isLoadingParameters = gettingSDRParameters;
+        const missingRequiredParameters = !sampleRate || !gain || sampleRate === 'none' || gain === 'none' || selectedAntenna === 'none';
+        return isStreamingActive || noSDRSelected || isLoadingParameters || missingRequiredParameters;
+    }, [isStreaming, selectedSDRId, gettingSDRParameters, sampleRate, gain, selectedAntenna]);
+
+    return { startStreaming, stopStreaming, playButtonEnabledOrNot };
+};
+
+export default useWaterfallStream;

--- a/frontend/src/components/waterfall/waterfall-control-bar.jsx
+++ b/frontend/src/components/waterfall/waterfall-control-bar.jsx
@@ -1,0 +1,292 @@
+import React from 'react';
+import { Paper, Box, Stack, IconButton } from '@mui/material';
+import StopIcon from '@mui/icons-material/Stop';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import AlignHorizontalLeftIcon from '@mui/icons-material/AlignHorizontalLeft';
+import AlignHorizontalRightIcon from '@mui/icons-material/AlignHorizontalRight';
+import AutoGraphIcon from '@mui/icons-material/AutoGraph';
+import HeightIcon from '@mui/icons-material/Height';
+import FullscreenIcon from '@mui/icons-material/Fullscreen';
+import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
+import ZoomInIcon from '@mui/icons-material/ZoomIn';
+import ZoomOutIcon from '@mui/icons-material/ZoomOut';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import ErrorIcon from '@mui/icons-material/Error';
+import { VFO1Icon, VFO2Icon, VFO3Icon, VFO4Icon } from '../common/icons.jsx';
+
+const WaterfallControlBar = ({
+    startStreamingLoading,
+    playButtonDisabled,
+    startStreaming,
+    stopStreaming,
+    isStreaming,
+    showLeftSideWaterFallAccessories,
+    toggleLeftSideWaterFallAccessories,
+    showRightSideWaterFallAccessories,
+    toggleRightSideWaterFallAccessories,
+    autoDBRange,
+    toggleAutoDBRange,
+    autoScale,
+    toggleFullscreen,
+    isFullscreen,
+    handleZoomIn,
+    handleZoomOut,
+    handleZoomReset,
+    vfoColors,
+    vfoActive,
+    toggleVfo,
+    fftDataOverflow
+}) => (
+    <Paper elevation={1} sx={{
+        p: 0,
+        display: 'inline-block',
+        width: '100%',
+        borderBottom: '1px solid',
+        borderColor: '#434343',
+        paddingBottom: '0px',
+        borderRadius: 0,
+    }}>
+        <Box sx={{
+            width: '100%',
+            overflowX: 'auto',
+            msOverflowStyle: 'none',
+            scrollbarWidth: 'none',
+            '&::-webkit-scrollbar': { display: 'none' }
+        }}>
+            <Stack
+                direction="row"
+                spacing={0}
+                sx={{
+                    minWidth: 'min-content',
+                    flexWrap: 'nowrap'
+                }}
+            >
+                <IconButton
+                    loading={startStreamingLoading}
+                    disabled={playButtonDisabled}
+                    color="primary"
+                    onClick={startStreaming}
+                    title="Start streaming"
+                    sx={{ borderRadius: 0 }}
+                >
+                    <PlayArrowIcon/>
+                </IconButton>
+
+                <IconButton
+                    disabled={!isStreaming}
+                    color="error"
+                    onClick={stopStreaming}
+                    title="Stop streaming"
+                    sx={{ borderRadius: 0 }}
+                >
+                    <StopIcon/>
+                </IconButton>
+
+                <IconButton
+                    color={showLeftSideWaterFallAccessories ? 'warning' : 'default'}
+                    onClick={toggleLeftSideWaterFallAccessories}
+                    size="small"
+                    title="Toggle left side panel"
+                    sx={{
+                        borderRadius: 0,
+                        backgroundColor: showLeftSideWaterFallAccessories ? 'rgba(25, 118, 210, 0.1)' : 'transparent',
+        '&:hover': {
+                            backgroundColor: showLeftSideWaterFallAccessories ? 'rgba(25, 118, 210, 0.2)' : 'rgba(0, 0, 0, 0.1)'
+                        }
+                    }}
+                >
+                    <AlignHorizontalLeftIcon/>
+                </IconButton>
+
+                <IconButton
+                    color={showRightSideWaterFallAccessories ? 'warning' : 'default'}
+                    onClick={toggleRightSideWaterFallAccessories}
+                    size="small"
+                    title="Toggle right side panel"
+                    sx={{
+                        borderRadius: 0,
+                        backgroundColor: showRightSideWaterFallAccessories ? 'rgba(25, 118, 210, 0.1)' : 'transparent',
+                        '&:hover': {
+                            backgroundColor: showRightSideWaterFallAccessories ? 'rgba(25, 118, 210, 0.2)' : 'rgba(0, 0, 0, 0.1)'
+                        }
+                    }}
+                >
+                    <AlignHorizontalRightIcon/>
+                </IconButton>
+                <IconButton
+                    onClick={toggleAutoDBRange}
+                    size="small"
+                    color={autoDBRange ? 'warning' : 'primary'}
+                    title="Toggle automatic dB range"
+                    sx={{
+                        borderRadius: 0,
+                        backgroundColor: autoDBRange ? 'rgba(46, 125, 50, 0.1)' : 'transparent',
+                        '&:hover': {
+                            backgroundColor: autoDBRange ? 'rgba(46, 125, 50, 0.2)' : 'rgba(25, 118, 210, 0.1)'
+                        }
+                    }}
+                >
+                    <AutoGraphIcon/>
+                </IconButton>
+
+                <IconButton
+                    sx={{ borderRadius: 0 }}
+                    onClick={autoScale}
+                    size="small"
+                    color="primary"
+                    title="Auto scale dB range once"
+                >
+                    <HeightIcon/>
+                </IconButton>
+
+                <IconButton
+                    sx={{ borderRadius: 0 }}
+                    onClick={toggleFullscreen}
+                    color="primary"
+                    title="Toggle fullscreen"
+                >
+                    {isFullscreen ? <FullscreenExitIcon/> : <FullscreenIcon/>}
+                </IconButton>
+                <IconButton
+                    sx={{ borderRadius: 0 }}
+                    onClick={handleZoomIn}
+                    color="primary"
+                    title="Zoom in"
+                >
+                    <ZoomInIcon/>
+                </IconButton>
+
+                <IconButton
+                    sx={{ borderRadius: 0 }}
+                    onClick={handleZoomOut}
+                    color="primary"
+                    title="Zoom out"
+                >
+                    <ZoomOutIcon/>
+                </IconButton>
+
+                <IconButton
+                    sx={{ borderRadius: 0 }}
+                    onClick={handleZoomReset}
+                    color="primary"
+                    title="Reset zoom"
+                >
+                    <RestartAltIcon/>
+                </IconButton>
+                <IconButton
+                    sx={{
+                        borderRadius: 0,
+                        width: 40,
+                        fontSize: '1.25rem',
+                        fontFamily: 'Monospace',
+                        fontWeight: 'bold',
+                        color: vfoColors[0],
+                        backgroundColor: vfoActive[1] ? 'rgba(255, 0, 0, 0.1)' : 'transparent',
+                        '&:hover': {
+                            backgroundColor: vfoActive[1] ? 'rgba(255, 0, 0, 0.2)' : 'rgba(0,0,0,0.1)'
+                        },
+                        '& .MuiTouchRipple-root': {
+                            border: vfoActive[1] ? '1px solid' : 'none',
+                            borderColor: '#ff0000',
+                        },
+                    }}
+                    onClick={() => toggleVfo(1)}
+                    color={vfoActive[1] ? 'warning' : 'primary'}
+                    title="Toggle VFO 1"
+                >
+                    <VFO1Icon/>
+                </IconButton>
+
+                <IconButton
+                    sx={{
+                        borderRadius: 0,
+                        width: 40,
+                        fontSize: '1.25rem',
+                        fontFamily: 'Monospace',
+                        fontWeight: 'bold',
+                        color: vfoColors[1],
+                        backgroundColor: vfoActive[2] ? 'rgba(0,255,0,0.1)' : 'transparent',
+                        '&:hover': {
+                            backgroundColor: vfoActive[2] ? 'rgba(0,255,0,0.2)' : 'rgba(0,0,0,0.1)'
+                        },
+                        '& .MuiTouchRipple-root': {
+                            border: vfoActive[2] ? '1px solid' : 'none',
+                            borderColor: 'rgba(0,255,0,0.7)',
+                        },
+                    }}
+                    onClick={() => toggleVfo(2)}
+                    color={vfoActive[2] ? 'warning' : 'primary'}
+                    title="Toggle VFO 2"
+                >
+                    <VFO2Icon/>
+                </IconButton>
+
+                <IconButton
+                    sx={{
+                        borderRadius: 0,
+                        width: 40,
+                        fontSize: '1.25rem',
+                        fontFamily: 'Monospace',
+                        fontWeight: 'bold',
+                        color: vfoColors[2],
+                        backgroundColor: vfoActive[3] ? 'rgba(0,0,255,0.1)' : 'transparent',
+                        '&:hover': {
+                            backgroundColor: vfoActive[3] ? 'rgba(18,49,255,0.78)' : 'rgba(0,0,0,0.1)'
+                        },
+                        '& .MuiTouchRipple-root': {
+                            border: vfoActive[3] ? '1px solid' : 'none',
+                            borderColor: 'rgba(18,49,255,0.8)',
+                        },
+                    }}
+                    onClick={() => toggleVfo(3)}
+                    color={vfoActive[3] ? 'warning' : 'primary'}
+                    title="Toggle VFO 3"
+                >
+                    <VFO3Icon/>
+                </IconButton>
+
+                <IconButton
+                    sx={{
+                        borderRadius: 0,
+                        width: 40,
+                        fontSize: '1.25rem',
+                        fontFamily: 'Monospace',
+                        fontWeight: 'bold',
+                        color: vfoColors[3],
+                        backgroundColor: vfoActive[4] ? 'rgba(255,0,255,0.1)' : 'transparent',
+                        '&:hover': {
+                            backgroundColor: vfoActive[4] ? 'rgba(255,0,255,0.2)' : 'rgba(0,0,0,0.1)'
+                        },
+                        '& .MuiTouchRipple-root': {
+                            border: vfoActive[4] ? '1px solid' : 'none',
+                            borderColor: 'rgba(163,0,218,0.77)',
+                        },
+                    }}
+                    onClick={() => toggleVfo(4)}
+                    color={vfoActive[4] ? 'warning' : 'primary'}
+                    title="Toggle VFO 4"
+                >
+                    <VFO4Icon/>
+                </IconButton>
+
+                {fftDataOverflow && (
+                    <IconButton
+                        sx={{
+                            borderRadius: 0,
+                            ml: 1,
+                            backgroundColor: 'rgba(211, 47, 47, 0.15)',
+                            '&:hover': { backgroundColor: 'rgba(211, 47, 47, 0.25)' }
+                        }}
+                        color="error"
+                        title="FFT update rate overflow — incoming updates are being throttled"
+                        disabled
+                    >
+                        <ErrorIcon />
+                    </IconButton>
+                )}
+            </Stack>
+        </Box>
+    </Paper>
+);
+
+export default WaterfallControlBar;

--- a/frontend/src/components/waterfall/waterfall-error-dialog.jsx
+++ b/frontend/src/components/waterfall/waterfall-error-dialog.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, Typography } from '@mui/material';
+import ErrorIcon from '@mui/icons-material/Error';
+
+const WaterfallErrorDialog = ({ open, message, onClose }) => (
+    <Dialog open={open} onClose={onClose} aria-labelledby="error-dialog-title" aria-describedby="error-dialog-description">
+        <DialogTitle id="error-dialog-title" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <ErrorIcon color="error" />
+            <Typography variant="h6" sx={{ fontWeight: 'bold' }}>Error Occurred</Typography>
+        </DialogTitle>
+        <DialogContent>
+            <DialogContentText id="error-dialog-description" sx={{ whiteSpace: 'pre-wrap' }}>
+                {message}
+            </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+            <Button onClick={onClose} variant="contained" color="error" autoFocus>
+                Close
+            </Button>
+        </DialogActions>
+    </Dialog>
+);
+
+export default WaterfallErrorDialog;


### PR DESCRIPTION
## Summary
- extract control bar and error dialog into standalone waterfall components
- centralize SDR streaming and socket logic with new `useWaterfallStream` hook
- streamline `waterfall-island.jsx` as a container using the new pieces

## Testing
- `npm run lint` *(fails: Unexpected lexical declaration in case block, unused vars, process undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68becba3036c8326ab2edee5be055277