### PR TITLE
fix(webrtc): validate source_url to prevent SSRF in /api/webrtc/offer

### DIFF
--- a/backend/video/webrtc.py
+++ b/backend/video/webrtc.py
@@ -1,13 +1,40 @@
 """WebRTC helper models and routes."""
 
 import json
+import os
 from typing import Dict, Optional
+from urllib.parse import urlparse
 
 import httpx
 from fastapi import FastAPI, HTTPException, WebSocket
 from pydantic import BaseModel
 
 from common.logger import logger
+
+# Allowlist of permitted go2rtc base URLs.  Override via the GO2RTC_ALLOWED_HOSTS
+# environment variable (comma-separated list of "host:port" entries).
+_DEFAULT_ALLOWED_HOSTS = {"localhost:1984", "127.0.0.1:1984"}
+
+def _allowed_hosts() -> set:
+    env = os.environ.get("GO2RTC_ALLOWED_HOSTS")
+    if env:
+        return {h.strip() for h in env.split(",") if h.strip()}
+    return _DEFAULT_ALLOWED_HOSTS
+
+
+def _validate_source_url(url: str) -> None:
+    """Raise HTTPException if *url* does not point to an allowed go2rtc host."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(status_code=400, detail="Invalid source_url scheme")
+    host = parsed.hostname or ""
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    netloc = f"{host}:{port}"
+    if netloc not in _allowed_hosts():
+        raise HTTPException(
+            status_code=400,
+            detail="source_url host is not in the allowed go2rtc hosts list",
+        )
 
 
 class RTCSessionDescription(BaseModel):
@@ -43,6 +70,7 @@ def register_webrtc_routes(app: FastAPI) -> None:
     @app.post("/api/webrtc/offer")
     async def create_webrtc_session(request: WebRTCRequest):
         """Relay WebRTC offer to go2rtc and return an answer."""
+        _validate_source_url(request.source_url)
         try:
             base_url = request.source_url.split("/stream.html")[0]
             webrtc_url = f"{base_url}/api/webrtc"
@@ -64,6 +92,8 @@ def register_webrtc_routes(app: FastAPI) -> None:
                     )
                 answer_data = response.json()
                 return RTCSessionDescription(type=answer_data["type"], sdp=answer_data["sdp"])
+        except HTTPException:
+            raise
         except Exception as e:  # pragma: no cover - network errors
             logger.error(f"Error creating WebRTC session: {str(e)}")
             raise HTTPException(


### PR DESCRIPTION
## Summary

The `POST /api/webrtc/offer` endpoint in `backend/video/webrtc.py` accepts a user-supplied `source_url` parameter and passes it directly to `httpx` to make a server-side HTTP request. There is no validation on the URL's destination, which means an attacker with network access to the application can use this endpoint as an open HTTP proxy to reach internal services, cloud metadata endpoints, or other hosts that should not be accessible from the outside.

This is a Server-Side Request Forgery vulnerability (CWE-918).

## Vulnerability Details

**Affected file:** `backend/video/webrtc.py`
**Affected endpoint:** `POST /api/webrtc/offer`
**Affected function:** `create_webrtc_session`

The `WebRTCRequest` model accepts a `source_url` string. In `create_webrtc_session`, the code splits this URL and constructs a new URL (`{base_url}/api/webrtc`), then sends a POST request via `httpx.AsyncClient()`. Since the application has no authentication on its endpoints, any network-reachable client can invoke this.

**Data flow:**
1. Attacker sends `POST /api/webrtc/offer` with `{"source_url": "http://169.254.169.254/stream.html", "sdp": "...", "type": "offer"}`
2. The handler splits on `/stream.html` → `base_url = "http://169.254.169.254"`
3. Constructs `webrtc_url = "http://169.254.169.254/api/webrtc"`
4. `httpx` sends a POST request to that URL from the server's network context
5. The response (or error details) is returned to the attacker

## Proof of Concept

With the application running locally on port 8000:

```bash
# Attempt to reach AWS cloud metadata via SSRF
curl -X POST http://localhost:8000/api/webrtc/offer \
  -H "Content-Type: application/json" \
  -d '{
    "source_url": "http://169.254.169.254/stream.html",
    "sdp": "v=0\r\no=- 0 0 IN IP4 0.0.0.0\r\ns=-\r\nt=0 0\r\n",
    "type": "offer"
  }'

# Attempt to reach internal Docker API
curl -X POST http://localhost:8000/api/webrtc/offer \
  -H "Content-Type: application/json" \
  -d '{
    "source_url": "http://127.0.0.1:2375/stream.html",
    "sdp": "v=0\r\no=- 0 0 IN IP4 0.0.0.0\r\ns=-\r\nt=0 0\r\n",
    "type": "offer"
  }'
```

Without the fix, `httpx` will attempt to connect to the attacker-specified host from the server's network perspective. The connection attempt itself confirms the SSRF — even if the target doesn't return a valid WebRTC response, the server-side request is made.

## Fix Description

This PR adds a `_validate_source_url()` function that checks the `source_url` against an allowlist of permitted go2rtc hosts before making any outbound request. By default, only `localhost:1984` and `127.0.0.1:1984` (the standard go2rtc addresses) are allowed. The allowlist is configurable via the `GO2RTC_ALLOWED_HOSTS` environment variable for deployments where go2rtc runs on a different host.

The validation:
- Rejects non-HTTP(S) schemes (blocks `file://`, `gopher://`, etc.)
- Parses the URL with `urllib.parse.urlparse` and checks `hostname:port` against the allowlist
- Defaults port to 80/443 based on scheme if not explicitly specified
- Re-raises `HTTPException` so validation errors aren't swallowed by the generic `except Exception` handler

## Testing

- Verified that requests with `source_url` pointing to allowed go2rtc hosts (`localhost:1984`, `127.0.0.1:1984`) pass validation
- Verified that requests targeting arbitrary hosts (e.g., `169.254.169.254`, `127.0.0.1:2375`) are rejected with HTTP 400
- Verified that non-HTTP schemes (`file://`, `gopher://`) are rejected
- Verified the `GO2RTC_ALLOWED_HOSTS` environment variable override works correctly
- Confirmed the fix is minimal (single file, 30 lines added) and doesn't change existing behavior for legitimate go2rtc communication

## Adversarial Review

Before submitting, we verified that no existing access controls or middleware protect this endpoint — the FastAPI app has no global authentication dependencies, and the `/api/webrtc/offer` route has no `Depends()` guards. The `source_url` reaches `httpx` without any sanitization. We also confirmed the endpoint is registered via `register_webrtc_routes(app)` and is reachable in a standard deployment.