### PR TITLE
fix(serve_spa): prevent path traversal in static file serving

### DIFF
--- a/backend/server/startup.py
+++ b/backend/server/startup.py
@@ -322,7 +322,13 @@ async def download_decoded_folder(foldername: str, background_tasks: BackgroundT
 async def serve_spa(request: Request, full_path: str):
     static_files_dir = os.environ.get("STATIC_FILES_DIR", "../../frontend/dist")
     if full_path.startswith(("static/", "assets/", "favicon.ico")):
-        return FileResponse(os.path.join(static_files_dir, full_path))
+        base_dir = Path(static_files_dir).resolve()
+        file_path = (base_dir / full_path).resolve()
+        try:
+            file_path.relative_to(base_dir)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid path")
+        return FileResponse(str(file_path))
     return FileResponse(os.path.join(static_files_dir, "index.html"))
 
 


### PR DESCRIPTION
## Vulnerability Summary

The `serve_spa` catch-all route in `backend/server/startup.py` (line 321) is vulnerable to **path traversal (CWE-22)**. The `full_path` parameter from the URL is joined directly to the static files directory and passed to `FileResponse` without any sanitization.

The route accepts any path matching `/{full_path:path}` and checks whether it starts with `static/`, `assets/`, or `favicon.ico`. A request like `GET /static/../../../etc/passwd` passes the `startswith("static/")` check but resolves to a file outside the intended static directory, allowing an attacker to read arbitrary files on the server.

**Affected function:** `serve_spa` at `backend/server/startup.py:322`
**Severity:** High — arbitrary file read with no authentication required
**CORS configuration:** `allow_origins=["*"]` (line 213), so this is exploitable cross-origin from any website

## Proof of Concept

```bash
# Start the ground-station server, then:
curl --path-as-is "http://localhost:8000/static/../../../etc/passwd"
```

The `startswith("static/")` check on line 324 passes because the path begins with `static/`. The `os.path.join(static_files_dir, "static/../../../etc/passwd")` call resolves to a path outside the static directory, and `FileResponse` serves the file contents.

To read application source code:

```bash
curl --path-as-is "http://localhost:8000/static/../../backend/server/startup.py"
```

## Fix Description

The fix resolves both the base directory and the requested file path to absolute paths using `Path.resolve()`, then verifies the resolved file path is within the base directory using `relative_to()`. If the resolved path escapes the static directory, a 400 error is returned.

```python
base_dir = Path(static_files_dir).resolve()
file_path = (base_dir / full_path).resolve()
try:
    file_path.relative_to(base_dir)
except ValueError:
    raise HTTPException(status_code=400, detail="Invalid path")
return FileResponse(str(file_path))
```

This is the standard Python approach for preventing path traversal — `resolve()` collapses all `..` sequences and symlinks, and `relative_to()` raises `ValueError` if the result is outside the allowed directory.

## Testing

- Verified that `GET /static/../../../etc/passwd` now returns HTTP 400 instead of file contents
- Verified that legitimate static file requests (`GET /static/js/app.js`, `GET /assets/logo.png`) continue to work correctly
- Verified that the SPA fallback route (non-static paths returning `index.html`) is unaffected

## Adversarial Review

Before submitting, we considered whether any existing protection would prevent exploitation. The route has no authentication — it is a public catch-all. The CORS policy is `allow_origins=["*"]`, so cross-origin exploitation is possible. The `startswith` check is not a security control; it is a routing decision that the traversal payload trivially satisfies by beginning with `static/`. There are no WAF or reverse-proxy path normalization layers configured in the application itself.