### PR TITLE
Enable map panning/zooming using gestures

### DIFF
--- a/frontend/src/components/common/common.jsx
+++ b/frontend/src/components/common/common.jsx
@@ -404,7 +404,11 @@ export function getTimeFromISO(isoString, timezone, locale) {
     });
 }
 
-export const MapArrowControls = function ({mapObject, verticalOffset = 0}) {
+export const MapArrowControls = function ({mapObject, verticalOffset = 0, onUserInteraction}) {
+    const pan = (offset) => {
+        onUserInteraction?.();
+        mapObject?.panBy(offset);
+    };
 
     return (
         <Box sx={{'& > :not(style)': {m: 1}}} style={{
@@ -419,7 +423,7 @@ export const MapArrowControls = function ({mapObject, verticalOffset = 0}) {
             width: 115,
         }}>
             <Fab size={"small"} variant="contained" color="primary" style={{margin: 0}}
-                 onClick={() => mapObject.panBy([0, -100])}>
+                 onClick={() => pan([0, -100])}>
                 <ArrowUpwardIcon/>
             </Fab>
             <Box sx={{
@@ -431,15 +435,15 @@ export const MapArrowControls = function ({mapObject, verticalOffset = 0}) {
                 width: '100%',
                 height: 15,
             }}>
-                <Fab size={"small"} color="primary" onClick={() => mapObject.panBy([-100, 0])} style={{margin: 0, position: 'absolute', left: 0}}>
+                <Fab size={"small"} color="primary" onClick={() => pan([-100, 0])} style={{margin: 0, position: 'absolute', left: 0}}>
                     <ArrowBackIcon/>
                 </Fab>
-                <Fab size={"small"} color="primary" variant="contained" onClick={() => mapObject.panBy([100, 0])} style={{margin: 0, position: 'absolute', right: 0}}>
+                <Fab size={"small"} color="primary" variant="contained" onClick={() => pan([100, 0])} style={{margin: 0, position: 'absolute', right: 0}}>
                     <ArrowForwardIcon/>
                 </Fab>
             </Box>
             <Fab size={"small"} color="primary" variant="contained" style={{margin: 0}}
-                 onClick={() => mapObject.panBy([0, 100])}>
+                 onClick={() => pan([0, 100])}>
                 <ArrowDownwardIcon/>
             </Fab>
         </Box>

--- a/frontend/src/components/common/map-interaction-sync.jsx
+++ b/frontend/src/components/common/map-interaction-sync.jsx
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright (c) 2025 Efstratios Goudelis
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+import {useEffect, useRef} from 'react';
+import {useMap} from 'react-leaflet';
+import L from 'leaflet';
+
+const ZOOM_HANDLER_KEYS = ['scrollWheelZoom', 'doubleClickZoom', 'touchZoom', 'boxZoom'];
+
+function setHandlerEnabled(handler, enabled) {
+    if (!handler) {
+        return;
+    }
+    if (enabled) {
+        handler.enable();
+    } else {
+        handler.disable();
+    }
+}
+
+/**
+ * Applies map drag/zoom gesture flags at runtime. When gesture zoom is disabled,
+ * Leaflet +/- buttons are shown instead (same as arrow pan when dragging is disabled).
+ */
+export function MapInteractionSync({
+    enableDragging,
+    enableZooming,
+    showZoomButtons,
+    onUserInteraction,
+}) {
+    const map = useMap();
+    const zoomControlRef = useRef(null);
+    const shouldShowZoomButtons = showZoomButtons ?? !enableZooming;
+
+    useEffect(() => {
+        setHandlerEnabled(map.dragging, enableDragging);
+        requestAnimationFrame(() => {
+            map.invalidateSize();
+        });
+    }, [map, enableDragging]);
+
+    useEffect(() => {
+        ZOOM_HANDLER_KEYS.forEach((key) => setHandlerEnabled(map[key], enableZooming));
+
+        if (shouldShowZoomButtons) {
+            if (!zoomControlRef.current) {
+                if (map.zoomControl) {
+                    map.removeControl(map.zoomControl);
+                }
+                const control = L.control.zoom({position: 'topleft'});
+                control.addTo(map);
+                zoomControlRef.current = control;
+            }
+        } else if (zoomControlRef.current) {
+            map.removeControl(zoomControlRef.current);
+            zoomControlRef.current = null;
+        }
+
+        requestAnimationFrame(() => {
+            map.invalidateSize();
+        });
+    }, [map, enableZooming, shouldShowZoomButtons]);
+
+    useEffect(() => {
+        return () => {
+            if (zoomControlRef.current) {
+                map.removeControl(zoomControlRef.current);
+                zoomControlRef.current = null;
+            }
+        };
+    }, [map]);
+
+    useEffect(() => {
+        if (!onUserInteraction) {
+            return undefined;
+        }
+
+        const handleDragStart = () => onUserInteraction();
+        const handleZoomStart = (event) => {
+            if (event?.originalEvent) {
+                onUserInteraction();
+            }
+        };
+
+        map.on('dragstart', handleDragStart);
+        map.on('zoomstart', handleZoomStart);
+
+        return () => {
+            map.off('dragstart', handleDragStart);
+            map.off('zoomstart', handleZoomStart);
+        };
+    }, [map, onUserInteraction]);
+
+    return null;
+}

--- a/frontend/src/components/common/map-settings.jsx
+++ b/frontend/src/components/common/map-settings.jsx
@@ -37,6 +37,8 @@ import {getTileLayerById, tileLayers} from './tile-layers.jsx';
 import { useTranslation } from 'react-i18next';
 
 const SETTINGS_KEYS = [
+    'enableMapDragging',
+    'enableMapZooming',
     'showPastOrbitPath',
     'showFutureOrbitPath',
     'showSatelliteCoverage',
@@ -70,6 +72,8 @@ const normalizeProjectionLabel = (projection) => {
 
 const buildSettings = ({
     initialLockOnTarget,
+    initialEnableMapDragging,
+    initialEnableMapZooming,
     initialShowPastOrbitPath,
     initialShowFutureOrbitPath,
     initialShowSatelliteCoverage,
@@ -85,6 +89,8 @@ const buildSettings = ({
     initialShowGrid,
 }) => ({
     lockOnTarget: Boolean(initialLockOnTarget),
+    enableMapDragging: Boolean(initialEnableMapDragging),
+    enableMapZooming: Boolean(initialEnableMapZooming),
     showPastOrbitPath: Boolean(initialShowPastOrbitPath),
     showFutureOrbitPath: Boolean(initialShowFutureOrbitPath),
     showSatelliteCoverage: Boolean(initialShowSatelliteCoverage),
@@ -130,6 +136,17 @@ const ToggleRow = ({ label, checked, onChange }) => (
         label={label}
         sx={{ ml: 0.2 }}
     />
+);
+
+const ToggleRowWithDescription = ({ label, description, checked, onChange }) => (
+    <Box>
+        <ToggleRow label={label} checked={checked} onChange={onChange} />
+        {description ? (
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', ml: 4.6, mt: -0.25 }}>
+                {description}
+            </Typography>
+        ) : null}
+    </Box>
 );
 
 const ColorSetting = ({ label, value, disabled = false, onChange }) => {
@@ -199,11 +216,13 @@ const ColorSetting = ({ label, value, disabled = false, onChange }) => {
     );
 };
 
-const MapSettingsIsland = ({ initialLockOnTarget, initialShowPastOrbitPath, initialShowFutureOrbitPath, initialShowSatelliteCoverage,
+const MapSettingsIsland = ({ initialLockOnTarget, initialEnableMapDragging, initialEnableMapZooming,
+                            initialShowPastOrbitPath, initialShowFutureOrbitPath, initialShowSatelliteCoverage,
                             initialShowSunIcon, initialShowMoonIcon, initialShowTerminatorLine,
                             initialSatelliteCoverageColor, initialPastOrbitLineColor, initialFutureOrbitLineColor,
                             initialOrbitProjectionDuration, initialTileLayerID, initialShowTooltip, initialShowGrid,
-                               handleLockOnTarget, handleShowFutureOrbitPath, handleShowPastOrbitPath,
+                               handleLockOnTarget, handleEnableMapDragging, handleEnableMapZooming,
+                               handleShowFutureOrbitPath, handleShowPastOrbitPath,
                             handleShowSatelliteCoverage, handleSetShowSunIcon, handleSetShowMoonIcon,
                             handleShowTerminatorLine, handleFutureOrbitLineColor, handlePastOrbitLineColor,
                             handleSatelliteCoverageColor, handleOrbitProjectionDuration, handleShowTooltip,
@@ -236,6 +255,8 @@ const MapSettingsIsland = ({ initialLockOnTarget, initialShowPastOrbitPath, init
     const initialSettings = useMemo(
         () => buildSettings({
             initialLockOnTarget,
+            initialEnableMapDragging,
+            initialEnableMapZooming,
             initialShowPastOrbitPath,
             initialShowFutureOrbitPath,
             initialShowSatelliteCoverage,
@@ -252,6 +273,8 @@ const MapSettingsIsland = ({ initialLockOnTarget, initialShowPastOrbitPath, init
         }),
         [
             initialLockOnTarget,
+            initialEnableMapDragging,
+            initialEnableMapZooming,
             initialShowPastOrbitPath,
             initialShowFutureOrbitPath,
             initialShowSatelliteCoverage,
@@ -271,6 +294,8 @@ const MapSettingsIsland = ({ initialLockOnTarget, initialShowPastOrbitPath, init
     const defaults = useMemo(
         () => buildSettings({
             initialLockOnTarget: defaultSettings?.lockOnTarget,
+            initialEnableMapDragging: defaultSettings?.enableMapDragging,
+            initialEnableMapZooming: defaultSettings?.enableMapZooming,
             initialShowPastOrbitPath: defaultSettings?.showPastOrbitPath,
             initialShowFutureOrbitPath: defaultSettings?.showFutureOrbitPath,
             initialShowSatelliteCoverage: defaultSettings?.showSatelliteCoverage,
@@ -323,6 +348,8 @@ const MapSettingsIsland = ({ initialLockOnTarget, initialShowPastOrbitPath, init
             satelliteCoverageColor: normalizeHexColor(draftSettings.satelliteCoverageColor, initialSettings.satelliteCoverageColor),
         };
 
+        handleEnableMapDragging?.(sanitizedSettings.enableMapDragging);
+        handleEnableMapZooming?.(sanitizedSettings.enableMapZooming);
         handleShowPastOrbitPath(sanitizedSettings.showPastOrbitPath);
         handleShowFutureOrbitPath(sanitizedSettings.showFutureOrbitPath);
         handleShowSatelliteCoverage(sanitizedSettings.showSatelliteCoverage);
@@ -416,6 +443,23 @@ const MapSettingsIsland = ({ initialLockOnTarget, initialShowPastOrbitPath, init
                             defaultValue: 'Switching map projection rebuilds the map canvas and may recenter the view.',
                         })}
                     </Typography>
+
+                    <ToggleRowWithDescription
+                        label={t('map_settings.enable_map_dragging', { defaultValue: 'Enable map dragging' })}
+                        description={t('map_settings.enable_map_dragging_desc', {
+                            defaultValue: 'Allow click-and-drag panning directly on the map.',
+                        })}
+                        checked={draftSettings.enableMapDragging}
+                        onChange={(value) => setDraftSettings((prev) => ({ ...prev, enableMapDragging: value }))}
+                    />
+                    <ToggleRowWithDescription
+                        label={t('map_settings.enable_map_zooming', { defaultValue: 'Enable map zooming' })}
+                        description={t('map_settings.enable_map_zooming_desc', {
+                            defaultValue: 'Allow mouse wheel, pinch, double-click, and zoom control buttons on the map.',
+                        })}
+                        checked={draftSettings.enableMapZooming}
+                        onChange={(value) => setDraftSettings((prev) => ({ ...prev, enableMapZooming: value }))}
+                    />
                 </SectionBlock>
 
                 <SectionBlock

--- a/frontend/src/components/overview/map-settings-dialog.jsx
+++ b/frontend/src/components/overview/map-settings-dialog.jsx
@@ -34,6 +34,8 @@ import {
     setShowSunIcon, setShowTerminatorLine, setShowTooltip, setTileLayerID,
     setOpenMapSettingsDialog,
     setShowGrid,
+    setEnableMapDragging,
+    setEnableMapZooming,
 } from "./overview-slice.jsx";
 
 function MapSettingsIslandDialog({updateBackend}) {
@@ -48,6 +50,8 @@ function MapSettingsIslandDialog({updateBackend}) {
         showTerminatorLine,
         showTooltip,
         showGrid,
+        enableMapDragging,
+        enableMapZooming,
         pastOrbitLineColor,
         futureOrbitLineColor,
         satelliteCoverageColor,
@@ -111,7 +115,11 @@ function MapSettingsIslandDialog({updateBackend}) {
                         initialShowTooltip={showTooltip}
                         initialShowTerminatorLine={showTerminatorLine}
                         initialShowGrid={showGrid}
+                        initialEnableMapDragging={enableMapDragging}
+                        initialEnableMapZooming={enableMapZooming}
                         defaultSettings={{
+                            enableMapDragging: false,
+                            enableMapZooming: false,
                             showPastOrbitPath: true,
                             showFutureOrbitPath: true,
                             showSatelliteCoverage: true,
@@ -138,6 +146,8 @@ function MapSettingsIslandDialog({updateBackend}) {
                         handleOrbitProjectionDuration={(value)=>{dispatch(setOrbitProjectionDuration(value))}}
                         handleShowTooltip={(value)=>{dispatch(setShowTooltip(value))}}
                         handleShowGrid={(value)=>{dispatch(setShowGrid(value))}}
+                        handleEnableMapDragging={(value)=>{dispatch(setEnableMapDragging(value))}}
+                        handleEnableMapZooming={(value)=>{dispatch(setEnableMapZooming(value))}}
                         handleTileLayerID={(value)=>{dispatch(setTileLayerID(value))}}
                         onCancel={handleCloseDialog}
                         updateBackend={updateBackend}

--- a/frontend/src/components/overview/overview-map.jsx
+++ b/frontend/src/components/overview/overview-map.jsx
@@ -57,6 +57,7 @@ import {
 } from '../common/common.jsx';
 import MapSettingsIslandDialog from './map-settings-dialog.jsx';
 import CoordinateGrid from '../common/mercator-grid.jsx';
+import {MapInteractionSync} from '../common/map-interaction-sync.jsx';
 import SatelliteTrackSuggestion from './map-target-button.jsx';
 import {
     calculateSatelliteAzEl,
@@ -188,6 +189,8 @@ const SatelliteMapContainer = ({handleSetTrackingOnBackend}) => {
         openMapSettingsDialog,
         nextPassesHours,
         showGrid,
+        enableMapDragging,
+        enableMapZooming,
         selectedSatelliteId,
         selectedSatGroupId,
         loadingSatellites,
@@ -835,15 +838,19 @@ const SatelliteMapContainer = ({handleSetTrackingOnBackend}) => {
                 </Backdrop>
                 {/* Leaflet CRS is immutable after map init, so remount when projection changes. */}
                 <MapContainer
-                    key={`overview-map-${selectedTileLayer.id}-${selectedTileLayer.projection || 'EPSG3857'}`}
+                    key={`overview-map-${selectedTileLayer.id}-${selectedTileLayer.projection || 'EPSG3857'}-${enableMapDragging}-${enableMapZooming}`}
                     className="overview-map"
                     fullscreenControl={true}
                     center={[0, 0]}
                     crs={mapCrs}
                     zoom={mapZoomLevel}
                     style={{width: '100%', height: '100%'}}
-                    dragging={false}
-                    scrollWheelZoom={false}
+                    dragging={enableMapDragging}
+                    scrollWheelZoom={enableMapZooming}
+                    doubleClickZoom={enableMapZooming}
+                    touchZoom={enableMapZooming}
+                    boxZoom={enableMapZooming}
+                    zoomControl={false}
                     maxZoom={10}
                     minZoom={0}
                     whenReady={handleWhenReady}
@@ -854,6 +861,11 @@ const SatelliteMapContainer = ({handleSetTrackingOnBackend}) => {
                     closePopupOnClick={false}
                 >
                 <MapEventComponent handleSetMapZoomLevel={handleSetMapZoomLevel}/>
+                <MapInteractionSync
+                    enableDragging={enableMapDragging}
+                    enableZooming={enableMapZooming}
+                    showZoomButtons={!enableMapZooming}
+                />
                 {selectedTileLayer.type === 'wms' ? (
                     <WMSTileLayer
                         url={selectedTileLayer.url}
@@ -923,10 +935,11 @@ const SatelliteMapContainer = ({handleSetTrackingOnBackend}) => {
                 {mapLayers.currentSatellitesCoverage}
                 {mapLayers.currentCrosshairs}
 
-                {/* Wrap MapArrowControls with a container to detect clicks */}
-                <div ref={arrowControlsRef}>
-                    <MapArrowControls mapObject={MapObject} verticalOffset={25}/>
-                </div>
+                {!enableMapDragging ? (
+                    <div ref={arrowControlsRef}>
+                        <MapArrowControls mapObject={MapObject} verticalOffset={25}/>
+                    </div>
+                ) : null}
 
                 {showGrid && (
                     <CoordinateGrid

--- a/frontend/src/components/overview/overview-slice.jsx
+++ b/frontend/src/components/overview/overview-slice.jsx
@@ -56,6 +56,8 @@ export const setOverviewMapSetting = createAsyncThunk(
             showTerminatorLine: state['overviewSatTrack']['showTerminatorLine'],
             showTooltip: state['overviewSatTrack']['showTooltip'],
             showGrid: state['overviewSatTrack']['showGrid'],
+            enableMapDragging: state['overviewSatTrack']['enableMapDragging'],
+            enableMapZooming: state['overviewSatTrack']['enableMapZooming'],
             pastOrbitLineColor: state['overviewSatTrack']['pastOrbitLineColor'],
             futureOrbitLineColor: state['overviewSatTrack']['futureOrbitLineColor'],
             satelliteCoverageColor: state['overviewSatTrack']['satelliteCoverageColor'],
@@ -212,6 +214,8 @@ const overviewSlice = createSlice({
         showTerminatorLine: true,
         showTooltip: false,
         showGrid: true,
+        enableMapDragging: false,
+        enableMapZooming: false,
         gridEditable: false,
         loadingSatellites: true,
         selectedSatellites: [],
@@ -402,6 +406,12 @@ const overviewSlice = createSlice({
         setShowGrid(state, action) {
             state.showGrid = action.payload;
         },
+        setEnableMapDragging(state, action) {
+            state.enableMapDragging = action.payload;
+        },
+        setEnableMapZooming(state, action) {
+            state.enableMapZooming = action.payload;
+        },
         setSelectedSatelliteId(state, action) {
             state.selectedSatelliteId = action.payload;
         },
@@ -536,6 +546,8 @@ const overviewSlice = createSlice({
                     state.showTerminatorLine = action.payload['showTerminatorLine'];
                     state.showTooltip = action.payload['showTooltip'];
                     state.showGrid = action.payload['showGrid'];
+                    state.enableMapDragging = action.payload['enableMapDragging'] ?? false;
+                    state.enableMapZooming = action.payload['enableMapZooming'] ?? false;
                     state.pastOrbitLineColor = action.payload['pastOrbitLineColor'];
                     state.futureOrbitLineColor = action.payload['futureOrbitLineColor'];
                     state.satelliteCoverageColor = action.payload['satelliteCoverageColor'];
@@ -582,6 +594,8 @@ export const {
     setOpenSatellitesTableSettingsDialog,
     setNextPassesHours,
     setShowGrid,
+    setEnableMapDragging,
+    setEnableMapZooming,
     setSelectedSatelliteId,
     setSatelliteData,
     setSelectedSatellitePositions,

--- a/frontend/src/components/target/map-settings-dialog.jsx
+++ b/frontend/src/components/target/map-settings-dialog.jsx
@@ -42,6 +42,8 @@ import {
     setTileLayerID,
     setOpenMapSettingsDialog,
     setShowGrid,
+    setEnableMapDragging,
+    setEnableMapZooming,
 } from "./target-slice.jsx";
 
 function MapSettingsIslandDialog({updateBackend}) {
@@ -63,6 +65,8 @@ function MapSettingsIslandDialog({updateBackend}) {
         tileLayerID,
         openMapSettingsDialog,
         showGrid,
+        enableMapDragging,
+        enableMapZooming,
     } = useSelector(state => state.targetSatTrack);
 
     const handleCloseDialog = () => {
@@ -120,8 +124,12 @@ function MapSettingsIslandDialog({updateBackend}) {
                         initialTileLayerID={tileLayerID}
                         initialShowTooltip={showTooltip}
                         initialShowGrid={showGrid}
+                        initialEnableMapDragging={enableMapDragging}
+                        initialEnableMapZooming={enableMapZooming}
                         initialShowTerminatorLine={showTerminatorLine}
                         defaultSettings={{
+                            enableMapDragging: false,
+                            enableMapZooming: false,
                             lockOnTarget: true,
                             showPastOrbitPath: true,
                             showFutureOrbitPath: true,
@@ -151,6 +159,8 @@ function MapSettingsIslandDialog({updateBackend}) {
                         handleShowTooltip={(value)=>{dispatch(setShowTooltip(value))}}
                         handleTileLayerID={(value)=>{dispatch(setTileLayerID(value))}}
                         handleShowGrid={(value)=>{dispatch(setShowGrid(value))}}
+                        handleEnableMapDragging={(value)=>{dispatch(setEnableMapDragging(value))}}
+                        handleEnableMapZooming={(value)=>{dispatch(setEnableMapZooming(value))}}
                         onCancel={handleCloseDialog}
                         updateBackend={updateBackend}
                     />

--- a/frontend/src/components/target/target-map.jsx
+++ b/frontend/src/components/target/target-map.jsx
@@ -81,6 +81,7 @@ import TargetNumberIcon from '../common/target-number-icon.jsx';
 import { useTooltipOrientation } from '../common/tooltip-orientation.js';
 import MapSettingsIslandDialog from './map-settings-dialog.jsx';
 import CoordinateGrid from "../common/mercator-grid.jsx";
+import {MapInteractionSync} from '../common/map-interaction-sync.jsx';
 import createTerminatorLine from "../common/terminator-line.jsx";
 import {getSunMoonCoords} from "../common/sunmoon.jsx";
 import SolarSystemCanvas from "../celestial/solarsystem-canvas.jsx";
@@ -304,12 +305,16 @@ const CenterHomeButton = React.memo(function CenterHomeButton() {
     );
 });
 
-const CenterMapButton = React.memo(function CenterMapButton() {
+const CenterMapButton = React.memo(function CenterMapButton({getCenterCoordinates, onCenterClick}) {
     const { t } = useTranslation('target');
-    const targetCoordinates = [0, 0];
 
     const handleClick = () => {
-        MapObject.setView(targetCoordinates, MapObject.getZoom());
+        const coords = getCenterCoordinates?.();
+        if (!coords || !MapObject) {
+            return;
+        }
+        MapObject.setView(coords, MapObject.getZoom());
+        onCenterClick?.();
     };
 
     return (
@@ -405,6 +410,8 @@ const TargetMapContainer = ({}) => {
         sliderTimeOffset,
         openMapSettingsDialog,
         showGrid,
+        enableMapDragging,
+        enableMapZooming,
     } = useSelector(state => state.targetSatTrack);
     const trackerInstances = useSelector((state) => state.trackerInstances?.instances || []);
     const targetNumber = useMemo(() => {
@@ -430,8 +437,12 @@ const TargetMapContainer = ({}) => {
         () => getMapCrsByTileLayerId(tileLayerID),
         [tileLayerID]
     );
-
     const satellitePosition = useSelector(satellitePositionSelector);
+    const getTargetCenterCoordinates = useCallback(() => {
+        const lat = satellitePosition?.lat;
+        const lon = satellitePosition?.lon;
+        return isValidLatLon(lat, lon) ? [lat, lon] : null;
+    }, [satellitePosition?.lat, satellitePosition?.lon]);
     const satelliteCoverage = useSelector(satelliteCoverageSelector);
     const satelliteDetails = useSelector(satelliteDetailsSelector);
     const trackingState = useSelector(trackingStateSelector);
@@ -739,8 +750,8 @@ const TargetMapContainer = ({}) => {
         MapObject = map.target;
     };
 
-    // Keep target map focused on the selected satellite.
-    // If coverage is shown, auto-fit to coverage bounds (legacy behavior).
+    // Recenters on the target whenever its position updates while lock-on-target is enabled.
+    // User pan/zoom is allowed between updates in both gesture and button modes.
     useEffect(() => {
         if (!isSatelliteTarget) return;
         if (!MapObject) return;
@@ -970,14 +981,18 @@ const TargetMapContainer = ({}) => {
             <Box sx={{ width: '100%', flex: 1, minHeight: 0, position: 'relative' }}>
                 {/* Leaflet CRS is immutable after map init, so remount when projection changes. */}
                 <MapContainer
-                    key={`target-map-${selectedTileLayer.id}-${selectedTileLayer.projection || 'EPSG3857'}`}
+                    key={`target-map-${selectedTileLayer.id}-${selectedTileLayer.projection || 'EPSG3857'}-${enableMapDragging}-${enableMapZooming}`}
                     className="target-map"
                     center={satellitePosition?.lat && satellitePosition?.lon ? [satellitePosition.lat, satellitePosition.lon] : [0, 0]}
                     crs={mapCrs}
                     zoom={mapZoomLevel}
                     style={{width: '100%', height: '100%'}}
-                    dragging={false}
-                    scrollWheelZoom={false}
+                    dragging={enableMapDragging}
+                    scrollWheelZoom={enableMapZooming}
+                    doubleClickZoom={enableMapZooming}
+                    touchZoom={enableMapZooming}
+                    boxZoom={enableMapZooming}
+                    zoomControl={false}
                     maxZoom={10}
                     minZoom={0}
                     whenReady={handleWhenReady}
@@ -988,6 +1003,11 @@ const TargetMapContainer = ({}) => {
                     closePopupOnClick={false}
                 >
                 <MapEventComponent handleSetMapZoomLevel={handleSetMapZoomLevel}/>
+                <MapInteractionSync
+                    enableDragging={enableMapDragging}
+                    enableZooming={enableMapZooming}
+                    showZoomButtons={!enableMapZooming}
+                />
 
                 {selectedTileLayer.type === 'wms' ? (
                     <WMSTileLayer
@@ -1009,7 +1029,7 @@ const TargetMapContainer = ({}) => {
                         </span>
                     </Tooltip>
                     <CenterHomeButton/>
-                    <CenterMapButton/>
+                    <CenterMapButton getCenterCoordinates={getTargetCenterCoordinates}/>
                     <FullscreenMapButton/>
                 </Box>
 
@@ -1064,8 +1084,9 @@ const TargetMapContainer = ({}) => {
                 {showSatelliteCoverage ? currentSatellitesCoverage : null}
 
 
-                {/* Arrow panning is only available in free-pan mode. */}
-                {!lockOnTarget ? <MapArrowControls mapObject={MapObject} verticalOffset={25}/> : null}
+                {!enableMapDragging ? (
+                    <MapArrowControls mapObject={MapObject} verticalOffset={25}/>
+                ) : null}
 
                 {showGrid && (
                     <CoordinateGrid

--- a/frontend/src/components/target/target-slice.jsx
+++ b/frontend/src/components/target/target-slice.jsx
@@ -339,6 +339,8 @@ export const setTargetMapSetting = createAsyncThunk(
             showTerminatorLine: state['targetSatTrack']['showTerminatorLine'],
             showTooltip: state['targetSatTrack']['showTooltip'],
             showGrid: state['targetSatTrack']['showGrid'],
+            enableMapDragging: state['targetSatTrack']['enableMapDragging'],
+            enableMapZooming: state['targetSatTrack']['enableMapZooming'],
             pastOrbitLineColor: state['targetSatTrack']['pastOrbitLineColor'],
             futureOrbitLineColor: state['targetSatTrack']['futureOrbitLineColor'],
             satelliteCoverageColor: state['targetSatTrack']['satelliteCoverageColor'],
@@ -699,6 +701,8 @@ const targetSatTrackSlice = createSlice({
         showTerminatorLine: true,
         showTooltip: true,
         showGrid: true,
+        enableMapDragging: false,
+        enableMapZooming: false,
         currentSatellitesPosition: [],
         currentSatellitesCoverage: [],
         terminatorLine: [],
@@ -1255,6 +1259,12 @@ const targetSatTrackSlice = createSlice({
         setShowGrid(state, action) {
             state.showGrid = action.payload;
         },
+        setEnableMapDragging(state, action) {
+            state.enableMapDragging = action.payload;
+        },
+        setEnableMapZooming(state, action) {
+            state.enableMapZooming = action.payload;
+        },
         setRotatorData(state, action) {
             state.rotatorData = action.payload;
         },
@@ -1630,6 +1640,8 @@ const targetSatTrackSlice = createSlice({
                     state.showTerminatorLine = action.payload['showTerminatorLine'];
                     state.showTooltip = action.payload['showTooltip'];
                     state.showGrid = action.payload['showGrid'];
+                    state.enableMapDragging = action.payload['enableMapDragging'] ?? false;
+                    state.enableMapZooming = action.payload['enableMapZooming'] ?? false;
                     state.pastOrbitLineColor = action.payload['pastOrbitLineColor'];
                     state.futureOrbitLineColor = action.payload['futureOrbitLineColor'];
                     state.satelliteCoverageColor = action.payload['satelliteCoverageColor'];
@@ -1704,6 +1716,8 @@ export const {
     setAvailableTransmitters,
     setTargetTransmitters,
     setShowGrid,
+    setEnableMapDragging,
+    setEnableMapZooming,
     setColorMap,
     setColorMaps,
     setDbRange,

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -115,6 +115,10 @@
     "day_night_separator": "Day/night separator line",
     "satellite_tooltip": "Satellite tooltip",
     "coordinate_grid": "Coordinate grid",
+    "enable_map_dragging": "Enable map dragging",
+    "enable_map_dragging_desc": "Allow click-and-drag panning on the map. When off, use the arrow buttons to pan.",
+    "enable_map_zooming": "Enable map zooming",
+    "enable_map_zooming_desc": "Allow mouse wheel, pinch, and double-click zoom on the map. When off, use the +/- buttons on the map.",
     "footprint_color": "Footprint color",
     "past_orbit_color": "Past orbit line color",
     "future_orbit_color": "Future orbit line color"


### PR DESCRIPTION

# Enable map pan/zoom gestures

Add controls to the map control modal to enable/disable free pan/zoom by gestures
Disable default map controls (4 direction arrows, -+ zooming) when new controls is enabled Keep center tracking target if 'Lock on target' is enabled

#Features
#75

### Screenshot

##### Enable/Disable pan/zoom by gestures
<img width="577" height="288" alt="new map controls" src="https://github.com/user-attachments/assets/fb0f1f71-7f53-4352-ba16-e9d854cad454" />



##### Default map control buttons is disable if new pan/zoom options are enabled
<img width="624" height="518" alt="image" src="https://github.com/user-attachments/assets/967fe333-6228-4b58-ae72-976f1a6d3dd9" />


