### PR TITLE
fix(auth): enforce admin-only access to session IP/snapshot data

### DIFF
--- a/backend/common/auth.py
+++ b/backend/common/auth.py
@@ -46,6 +46,9 @@ _setup_cache_ttl_seconds = 3.0
 _setup_cache: Dict[str, Any] = {"value": True, "expires_at": 0.0}
 _sqlite_lock_retry_delays_seconds = (0.25, 0.5, 1.0, 2.0)
 AUTH_SESSION_COOKIE_NAME = "gs_session"
+# Socket.IO room that receives admin-only broadcasts (e.g. session runtime snapshots
+# containing client IP addresses). Sockets join/leave this room based on their live role.
+ADMIN_SOCKET_ROOM = "admins"
 SETUP_MODE_NONE = "none"
 SETUP_MODE_FULL = "full_setup"
 SETUP_MODE_ADMIN_RECOVERY = "admin_recovery"
@@ -97,6 +100,10 @@ admin_only_commands = {
     "submit-transmitter",
     "edit-transmitter",
     "delete-transmitter",
+    # Session runtime snapshots expose client IP addresses and per-session config,
+    # which the issue flags as sensitive. Restrict this introspection to admins.
+    "fetch_runtime_snapshot",
+    "fetch_session_view",
 }
 
 admin_only_prefixes = (

--- a/backend/handlers/socket.py
+++ b/backend/handlers/socket.py
@@ -66,6 +66,22 @@ SOCKET_TOKENS: Dict[str, str] = {}
 def register_socketio_handlers(sio):
     """Register Socket.IO event handlers."""
 
+    async def _sync_admin_room(sid: str, auth_context: Optional[Dict[str, Any]]) -> None:
+        """Keep the admin-only broadcast room membership in sync with the socket's live role.
+
+        Session runtime snapshots leak client IP addresses, so they are emitted only to the
+        admin room. Re-syncing on connect and on every api.call lets role promotions and
+        demotions take effect without requiring the client to reconnect.
+        """
+        is_admin = authsvc.is_admin_role((auth_context or {}).get("role"))
+        try:
+            if is_admin:
+                await sio.enter_room(sid, authsvc.ADMIN_SOCKET_ROOM)
+            else:
+                await sio.leave_room(sid, authsvc.ADMIN_SOCKET_ROOM)
+        except Exception:
+            logger.debug("Failed to sync admin room for sid=%s", sid, exc_info=True)
+
     @sio.on("connect")
     async def connect(sid, environ, auth=None):
         # Prefer reverse-proxy header if present, else fall back to REMOTE_ADDR.
@@ -136,6 +152,9 @@ def register_socketio_handlers(sio):
             )
         except Exception:
             logger.debug("Failed to set session metadata in tracker", exc_info=True)
+
+        # Join the admin room so only admins receive IP-bearing session snapshots.
+        await _sync_admin_room(sid, auth_context)
 
         # Send current running tasks to newly connected client.
         if runtimestate.background_task_manager:
@@ -213,6 +232,10 @@ def register_socketio_handlers(sio):
                 )
             except Exception:
                 logger.debug("Failed to refresh session owner metadata", exc_info=True)
+
+        # Re-sync admin room membership so role changes (promote/demote) apply immediately,
+        # gating who keeps receiving IP-bearing session snapshot broadcasts.
+        await _sync_admin_room(sid, auth_context)
 
         reply = await dispatch_request(
             sio,

--- a/backend/server/sessionsnapshot.py
+++ b/backend/server/sessionsnapshot.py
@@ -9,6 +9,7 @@ registers an asyncio.Task into the provided `background_tasks` set.
 import asyncio
 from typing import Set
 
+from common import auth as authsvc
 from common.logger import logger
 from pipeline.orchestration.processmanager import process_manager
 from session.service import session_service
@@ -18,8 +19,9 @@ from session.tracker import session_tracker
 def start_session_runtime_emitter(sio, background_tasks: Set[asyncio.Task]) -> asyncio.Task:
     """Start the session runtime snapshot emitter loop and register it in background_tasks.
 
-    Emits 'session-runtime-snapshot' every 1 second to all connected clients.
-    The snapshot includes all active sessions, their metadata, and SDR consumer state.
+    Emits 'session-runtime-snapshot' every 1 second to admin clients only.
+    The snapshot includes all active sessions, their metadata (including client IP
+    addresses), and SDR consumer state, so it is restricted to the admin room.
     """
 
     async def _session_snapshot_loop():
@@ -39,9 +41,13 @@ def start_session_runtime_emitter(sio, background_tasks: Set[asyncio.Task]) -> a
                     except Exception as e2:
                         logger.debug(f"Tracker fallback also failed: {e2}")
 
-                # Emit the snapshot to all connected clients
+                # Emit the snapshot to admins only; it carries client IP addresses.
                 if snapshot is not None:
-                    await sio.emit("session-runtime-snapshot", snapshot)
+                    await sio.emit(
+                        "session-runtime-snapshot",
+                        snapshot,
+                        room=authsvc.ADMIN_SOCKET_ROOM,
+                    )
 
                 await asyncio.sleep(interval)
             except asyncio.CancelledError:

--- a/backend/server/startup.py
+++ b/backend/server/startup.py
@@ -603,7 +603,9 @@ app.mount("/satimages", StaticFiles(directory=satellites_dir, html=True), name="
 app.mount(
     "/recordings", AuthenticatedStaticFiles(directory=recordings_dir, html=True), name="recordings"
 )
-app.mount("/snapshots", StaticFiles(directory=snapshots_dir, html=True), name="snapshots")
+app.mount(
+    "/snapshots", AuthenticatedStaticFiles(directory=snapshots_dir, html=True), name="snapshots"
+)
 app.mount("/decoded", AuthenticatedStaticFiles(directory=decoded_dir, html=True), name="decoded")
 app.mount("/audio", AuthenticatedStaticFiles(directory=audio_dir, html=True), name="audio")
 # Note: html=False for transcriptions to ensure .txt files are served with correct content-type

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -147,6 +147,12 @@ def test_operator_cannot_run_admin_only_commands():
     assert auth.is_command_allowed_for_role("update-system-preferences", "operator") is False
     assert auth.is_command_allowed_for_role("update-app-config", "operator") is False
     assert auth.is_command_allowed_for_role("database-backup.full_backup", "operator") is False
+    # Session runtime snapshots leak client IP addresses; operators must not read them.
+    assert auth.is_command_allowed_for_role("fetch_runtime_snapshot", "operator") is False
+    assert auth.is_command_allowed_for_role("fetch_session_view", "operator") is False
+    # Admins retain access to the same session introspection commands.
+    assert auth.is_command_allowed_for_role("fetch_runtime_snapshot", "admin") is True
+    assert auth.is_command_allowed_for_role("fetch_session_view", "admin") is True
 
 
 def test_setup_mode_only_allows_setup_scoped_commands():


### PR DESCRIPTION
### What
Closes three backend gaps where session IP addresses / per-session data were
reachable by `operator` users or unauthenticated requests, despite the RBAC added
in #37.

- Add `fetch_runtime_snapshot` and `fetch_session_view` to `admin_only_commands`
  (`common/auth.py`).
- Broadcast `session-runtime-snapshot` to an admin-only Socket.IO room instead of
  all clients. Sockets join/leave the room based on their **live** role, re-synced
  on connect and on every `api.call`, so promote/demote applies without a reconnect
  (`handlers/socket.py`, `server/sessionsnapshot.py`).
- Mount `/snapshots` via `AuthenticatedStaticFiles`, matching `/recordings`,
  `/audio`, `/decoded`, `/transcriptions` (`server/startup.py`).
- Extend `tests/test_auth.py` to assert operators are denied and admins allowed.

### Why
The admin UI already hides this data, but the backend didn't enforce it — a
low-privilege actor could read client IPs / session config directly. See #NNN.

### Testing
- `cd backend && ALEMBIC_CONTEXT=1 ./venv/bin/pytest -m unit tests/test_auth.py tests/testsocketauth.py`
- Manually verified an operator socket receives `Not authorized` for the two
  commands and no longer receives `session-runtime-snapshot`; `/snapshots/<file>`
  returns 401 without a cookie.

### Notes
- No new files / migrations. Static-asset mounts (`/satimages`, icons) left public
  by design — they're catalog reference data, not user data.
- Out of scope (still open in #37): external OAuth/SSO.

Refs #37
Fixes #78
